### PR TITLE
Adding the ability to provide environment variable through a system property

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ sbtPlugin := true
 name := "sbt-pillar"
 organization := "io.github.henders"
 description := "A wrapper over the Pillar library to manage Cassandra migrations (https://github.com/comeara/pillar)"
-version := "0.1.5"
+version := "0.1.6"
 
 licenses += ("MIT", url("https://opensource.org/licenses/MIT"))
 publishMavenStyle := false

--- a/src/main/scala/io/github/henders/CassandraMigrator.scala
+++ b/src/main/scala/io/github/henders/CassandraMigrator.scala
@@ -14,7 +14,7 @@ class CassandraMigrator(configFile: File, migrationsDir: File, logger: Logger) {
   private val DEFAULT_USERNAME = "cassandra"
   private val DEFAULT_PASSWORD = "cassandra"
 
-  val env = sys.env.getOrElse("SCALA_ENV", "development")
+  val env = sys.props.getOrElse("SCALA_ENV", sys.env.getOrElse("SCALA_ENV", "development"))
   logger.info(s"Loading config file: $configFile for environment: $env")
   val config = ConfigFactory.parseFile(configFile).resolve().getConfig(env)
   val cassandraConfig = config.getConfig("cassandra")


### PR DESCRIPTION
This allows us to do: `sbt cleanMigrate -DSCALA_ENV=test`.

If provided, the system property will override the `SCALA_ENV` environment variable.
If not provided, the system property will fallback to the `SCALA_ENV` environment variable.
If none is set, it will fallback to `development`, as before.
